### PR TITLE
add y-axis support to offsetters

### DIFF
--- a/api/src/main/java/com/jtprince/coordinateoffset/FixedOffset.java
+++ b/api/src/main/java/com/jtprince/coordinateoffset/FixedOffset.java
@@ -5,8 +5,8 @@ import com.jtprince.coordinateoffset.api.CoordinateOffset;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Amount by which a player's clientside X and Z coordinates will appear shifted compared to their real position in a
- * world.
+ * Amount by which a player's clientside X, Y, and Z coordinates will appear shifted compared to their real
+ * position in a world.
  *
  * <p>Fixed offsets are absolute in any coordinate space. For example, a fixed offset of <code>(800, 800)</code>
  * will <i>always</i> subtract 800 from the player's coordinates. This may break coordinate-based alignment between
@@ -14,11 +14,12 @@ import org.jspecify.annotations.NullMarked;
  *
  * <p>A fixed offset is fully resolved and may be applied to coordinates directly.</p>
  *
- * @param x X offset value in blocks. Will be subtracted from the player's real X coordinate.
- * @param z Z offset value in blocks. Will be subtracted from the player's real Z coordinate.
+ * @param x X offset value in blocks. Must be a multiple of 16. Will be subtracted from the player's real X coordinate.
+ * @param y Y offset value in blocks. Will be subtracted from the player's real Y coordinate.
+ * @param z Z offset value in blocks. Must be a multiple of 16. Will be subtracted from the player's real Z coordinate.
  */
 @NullMarked
-public record FixedOffset(int x, int z) implements Offset {
+public record FixedOffset(int x, int y, int z) implements Offset {
     public FixedOffset {
         if (x % 16 != 0) {
             throw new IllegalArgumentException("Offset x=" + x + " is not chunk-aligned! (must be a multiple of 16)");
@@ -30,17 +31,17 @@ public record FixedOffset(int x, int z) implements Offset {
 
     @Override
     public String toString() {
-        return "[x=" + x + ", z=" + z + "]";
+        return "[x=" + x + ", y=" + y + ", z=" + z + "]";
     }
 
     @Override
     public FixedOffset negate() {
-        return new FixedOffset(-x, -z);
+        return new FixedOffset(-x, -y, -z);
     }
 
     @Override
     public boolean isZero() {
-        return x == 0 && z == 0;
+        return x == 0 && y == 0 && z == 0;
     }
 
     public int chunkX() {

--- a/api/src/main/java/com/jtprince/coordinateoffset/Offset.java
+++ b/api/src/main/java/com/jtprince/coordinateoffset/Offset.java
@@ -35,14 +35,24 @@ public sealed interface Offset permits FixedOffset, ScalableOffset {
      * <p>{@link ScalableOffset} is recommended for most use cases. {@link FixedOffset} is only recommended if vanilla
      * nether portal travel is disabled, or if the offset provider is manually performing coordinate scaling.</p>
      *
-     * @param x X offset value in blocks. Must be a multiple of 16. Will be subtracted from the player's real X
-     *          coordinate.
-     * @param z Z offset value in blocks. Must be a multiple of 16. Will be subtracted from the player's real Z
-     *          coordinate.
+     * @param x X offset value in blocks. Must be a multiple of 16.
+     * @param z Z offset value in blocks. Must be a multiple of 16.
      * @return A new FixedOffset.
      */
     static FixedOffset fixed(int x, int z) {
-        return new FixedOffset(x, z);
+        return new FixedOffset(x, 0, z);
+    }
+
+    /**
+     * Create a new fixed offset with the given X, Y, and Z components.
+     *
+     * @param x X offset value in blocks. Must be a multiple of 16.
+     * @param y Y offset value in blocks.
+     * @param z Z offset value in blocks. Must be a multiple of 16.
+     * @return A new FixedOffset.
+     */
+    static FixedOffset fixed(int x, int y, int z) {
+        return new FixedOffset(x, y, z);
     }
 
     /**
@@ -60,22 +70,30 @@ public sealed interface Offset permits FixedOffset, ScalableOffset {
      * worlds. Players expect that entering a nether portal they see at <code>(-4000, 4000)</code> will bring them to
      * <code>(-500, 500)</code> in the nether.</p>
      *
-     * @param x X offset value in blocks. Will be scaled based on world, rounded to the nearest
-     *          <code>offsetsAreMultiplesOfBlocks</code> (likely 16) blocks, then subtracted from the player's real X
-     *          coordinate.
-     * @param z Z offset value in blocks. Will be scaled based on world, rounded to the nearest
-     *          <code>offsetsAreMultiplesOfBlocks</code> (likely 16) blocks, then subtracted from the player's real Z
-     *          coordinate.
+     * @param x X offset value in blocks.
+     * @param z Z offset value in blocks.
      * @return A new ScalableOffset.
      */
     static ScalableOffset scalable(int x, int z) {
-        return new ScalableOffset(x, z);
+        return new ScalableOffset(x, 0, z);
+    }
+
+    /**
+     * Create a new scalable offset with the given X, Y, and Z components.
+     *
+     * @param x X offset value in blocks.
+     * @param y Y offset value in blocks.
+     * @param z Z offset value in blocks.
+     * @return A new ScalableOffset.
+     */
+    static ScalableOffset scalable(int x, int y, int z) {
+        return new ScalableOffset(x, y, z);
     }
 
     /**
      * The "zero" or identity offset. This offset results in no transformation from real-world coordinates.
      */
-    FixedOffset ZERO = new FixedOffset(0, 0);
+    FixedOffset ZERO = new FixedOffset(0, 0, 0);
 
     /**
      * Align offset components to the nearest 8 chunks. This number is selected because the default nether has a
@@ -107,6 +125,7 @@ public sealed interface Offset permits FixedOffset, ScalableOffset {
     static ScalableOffset align(int x, int z) {
         return new ScalableOffset(
             alignComponentToConfiguredMultiple(x),
+            0,
             alignComponentToConfiguredMultiple(z)
         );
     }
@@ -133,7 +152,7 @@ public sealed interface Offset permits FixedOffset, ScalableOffset {
      */
     @Deprecated(forRemoval = true)
     static ScalableOffset align(int x, int z, int toChunksPower) {
-        return new ScalableOffset(alignComponent(x, toChunksPower), alignComponent(z, toChunksPower));
+        return new ScalableOffset(alignComponent(x, toChunksPower), 0, alignComponent(z, toChunksPower));
     }
 
     /**
@@ -149,6 +168,7 @@ public sealed interface Offset permits FixedOffset, ScalableOffset {
     static ScalableOffset random(int bound) {
         return new ScalableOffset(
             Offset.alignComponentToConfiguredMultiple(ScalableOffset.RANDOM.nextInt(bound)),
+            0,
             Offset.alignComponentToConfiguredMultiple(ScalableOffset.RANDOM.nextInt(bound))
         );
     }
@@ -176,6 +196,7 @@ public sealed interface Offset permits FixedOffset, ScalableOffset {
     static ScalableOffset random(int bound, int alignToChunksPower) {
         return new ScalableOffset(
             alignComponent(ScalableOffset.RANDOM.nextInt(bound), alignToChunksPower),
+            0,
             alignComponent(ScalableOffset.RANDOM.nextInt(bound), alignToChunksPower)
         );
     }

--- a/api/src/main/java/com/jtprince/coordinateoffset/ScalableOffset.java
+++ b/api/src/main/java/com/jtprince/coordinateoffset/ScalableOffset.java
@@ -8,8 +8,8 @@ import org.jspecify.annotations.NullMarked;
 import java.util.Random;
 
 /**
- * Amount by which a player's clientside X and Z coordinates will appear shifted compared to their real position in a
- * world.
+ * Amount by which a player's clientside X, Y, and Z coordinates will appear shifted compared to their real
+ * position in a world.
  *
  * <p>A scalable offset is scaled based on the coordinate system of the world the offset is applied in. For example,
  * a scalable offset of <code>(800, 800)</code> may subtract 800 blocks from the player's coordinates in the
@@ -18,18 +18,17 @@ import java.util.Random;
  * <p>Scalable offsets cannot be applied to coordinates directly. They must first be scaled to a {@link FixedOffset}
  * with the context of a world's coordinate scale. See {@link #scaleDownAndRound}.</p>
  *
- * @param x X offset value in blocks. Will be scaled based on world, then subtracted from the player's real X
- *          coordinate.
- * @param z Z offset value in blocks. Will be scaled based on world, then subtracted from the player's real Z
- *          coordinate.
+ * @param x X offset value in blocks. Will be scaled based on world, then subtracted from the player's real X coordinate.
+ * @param y Y offset value in blocks. Will be subtracted from the player's real Y coordinate.
+ * @param z Z offset value in blocks. Will be scaled based on world, then subtracted from the player's real Z coordinate.
  */
 @NullMarked
-public record ScalableOffset(int x, int z) implements Offset {
+public record ScalableOffset(int x, int y, int z) implements Offset {
     static final Random RANDOM = new Random();
 
     @Override
     public String toString() {
-        return "[x=" + x + ", z=" + z + "]";
+        return "[x=" + x + ", y=" + y + ", z=" + z + "]";
     }
 
     @Override
@@ -70,12 +69,12 @@ public record ScalableOffset(int x, int z) implements Offset {
 
     @Override
     public ScalableOffset negate() {
-        return new ScalableOffset(-x, -z);
+        return new ScalableOffset(-x, -y, -z);
     }
 
     @Override
     public boolean isZero() {
-        return x == 0 && z == 0;
+        return x == 0 && y == 0 && z == 0;
     }
 
     /**
@@ -88,6 +87,7 @@ public record ScalableOffset(int x, int z) implements Offset {
     public FixedOffset scaleDownAndRound(double divisor) {
         return new FixedOffset(
             Offset.alignComponentToConfiguredMultiple((int) (x / divisor)),
+            y,
             Offset.alignComponentToConfiguredMultiple((int) (z / divisor))
         );
     }
@@ -104,10 +104,11 @@ public record ScalableOffset(int x, int z) implements Offset {
     public FixedOffset scaleDownBy(double divisor) {
         if (divisor == 0.0) {
             // Special case - 0 would naturally result in a NaN/infinity offset, but interpret 0 scale as 0 offset
-            return new FixedOffset(0, 0);
+            return new FixedOffset(0, y, 0);
         }
         return new FixedOffset(
             Offset.alignComponent((int) (x / divisor), 0),
+            y,
             Offset.alignComponent((int) (z / divisor), 0)
         );
     }

--- a/api/src/test/java/com/jtprince/coordinateoffset/TestOffset.java
+++ b/api/src/test/java/com/jtprince/coordinateoffset/TestOffset.java
@@ -6,9 +6,11 @@ import org.junit.jupiter.api.Test;
 public class TestOffset {
     @Test
     void testNonAlignedThrowsException() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> Offset.fixed(-64, 24));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> Offset.fixed(100, 32));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> Offset.fixed(-1000, -100));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Offset.fixed(-64, 0, 24));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Offset.fixed(100, 0, 32));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Offset.fixed(-1000, 0, -100));
+        Assertions.assertDoesNotThrow(() -> Offset.fixed(0, 37, 0));
+        Assertions.assertDoesNotThrow(() -> Offset.fixed(0, -200, 0));
     }
 
     @Test
@@ -34,26 +36,43 @@ public class TestOffset {
     @Test
     void testAlignToMultipleChunks() {
         // Align to 16 chunks (nearest 256 blocks)
-        Assertions.assertEquals(new ScalableOffset(0, 0), Offset.align(-65, 65, 4));
-        Assertions.assertEquals(new ScalableOffset(0, 0), Offset.align(-128, 127, 4));
-        Assertions.assertEquals(new ScalableOffset(-256, 256), Offset.align(-129, 128, 4));
+        Assertions.assertEquals(new ScalableOffset(0, 0, 0), Offset.align(-65, 65, 4));
+        Assertions.assertEquals(new ScalableOffset(0, 0, 0), Offset.align(-128, 127, 4));
+        Assertions.assertEquals(new ScalableOffset(-256, 0, 256), Offset.align(-129, 128, 4));
     }
 
     @Test
     void testChunkValues() {
-        Assertions.assertEquals(5, Offset.fixed(80, 0).chunkX());
-        Assertions.assertEquals(-3, Offset.fixed(0, -48).chunkZ());
+        Assertions.assertEquals(5, Offset.fixed(80, 0, 0).chunkX());
+        Assertions.assertEquals(-3, Offset.fixed(0, 0, -48).chunkZ());
     }
 
     @Test
     void testScale() {
-        Assertions.assertEquals(new FixedOffset(64, -128), Offset.scalable(16, -32).scaleDownBy(0.25));
-        Assertions.assertEquals(new FixedOffset(-48, -128), Offset.scalable(-48, -128).scaleDownBy(1.0));
+        Assertions.assertEquals(new FixedOffset(64, 0, -128), Offset.scalable(16, 0, -32).scaleDownBy(0.25));
+        Assertions.assertEquals(new FixedOffset(-48, 0, -128), Offset.scalable(-48, 0, -128).scaleDownBy(1.0));
 
         // Clean scaling (dividing inputs by 8 still results in a multiple of 16)
-        Assertions.assertEquals(new FixedOffset(96, -176), Offset.scalable(768, -1408).scaleDownBy(8.0));
+        Assertions.assertEquals(new FixedOffset(96, 0, -176), Offset.scalable(768, 0, -1408).scaleDownBy(8.0));
         // Truncated scaling (dividing inputs by 8 does NOT result in a multiple of 16, so they must be aligned)
-        Assertions.assertEquals(new FixedOffset(-48, 16), Offset.scalable(-432, 144).scaleDownBy(8.0));
-        Assertions.assertEquals(new FixedOffset(-64, 32), Offset.scalable(-464, 192).scaleDownBy(8.0));
+        Assertions.assertEquals(new FixedOffset(-48, 0, 16), Offset.scalable(-432, 0, 144).scaleDownBy(8.0));
+        Assertions.assertEquals(new FixedOffset(-64, 0, 32), Offset.scalable(-464, 0, 192).scaleDownBy(8.0));
+    }
+
+    @Test
+    void testYOffset() {
+        FixedOffset withY = Offset.fixed(0, 128, 0);
+        Assertions.assertEquals(128, withY.y());
+
+        // Y is not scaled by world coordinate scale
+        ScalableOffset scalable = Offset.scalable(0, 64, 0);
+        Assertions.assertEquals(64, scalable.scaleDownBy(8.0).y());
+        Assertions.assertEquals(64, scalable.scaleDownBy(1.0).y());
+
+        Assertions.assertEquals(-128, Offset.fixed(0, 128, 0).negate().y());
+        Assertions.assertEquals(-64, Offset.scalable(0, 64, 0).negate().y());
+
+        Assertions.assertFalse(Offset.fixed(0, 1, 0).isZero());
+        Assertions.assertTrue(Offset.fixed(0, 0, 0).isZero());
     }
 }

--- a/core/src/main/java/com/jtprince/coordinateoffset/offsetter/PacketOffsetter.java
+++ b/core/src/main/java/com/jtprince/coordinateoffset/offsetter/PacketOffsetter.java
@@ -38,38 +38,38 @@ public abstract class PacketOffsetter<T extends PacketWrapper<T>> {
     public void onUserDisconnect(User user) {}
 
     protected static Vector3d apply(Vector3d vec, FixedOffset offset) {
-        return new Vector3d(vec.x - offset.x(), vec.y, vec.z - offset.z());
+        return new Vector3d(vec.x - offset.x(), vec.y - offset.y(), vec.z - offset.z());
     }
 
     protected static Vector3f apply(Vector3f vec, FixedOffset offset) {
-        return new Vector3f(vec.x - offset.x(), vec.y, vec.z - offset.z());
+        return new Vector3f(vec.x - offset.x(), vec.y - offset.y(), vec.z - offset.z());
     }
 
     protected static Vector3i apply(Vector3i vec, FixedOffset offset) {
-        return new Vector3i(vec.x - offset.x(), vec.y, vec.z - offset.z());
+        return new Vector3i(vec.x - offset.x(), vec.y - offset.y(), vec.z - offset.z());
     }
 
     protected static Vector3d unapply(Vector3d vec, FixedOffset offset) {
-        return new Vector3d(vec.x + offset.x(), vec.y, vec.z + offset.z());
+        return new Vector3d(vec.x + offset.x(), vec.y + offset.y(), vec.z + offset.z());
     }
 
     protected static Vector3f unapply(Vector3f vec, FixedOffset offset) {
-        return new Vector3f(vec.x + offset.x(), vec.y, vec.z + offset.z());
+        return new Vector3f(vec.x + offset.x(), vec.y + offset.y(), vec.z + offset.z());
     }
 
     protected static Vector3i unapply(Vector3i vec, FixedOffset offset) {
-        return new Vector3i(vec.x + offset.x(), vec.y, vec.z + offset.z());
+        return new Vector3i(vec.x + offset.x(), vec.y + offset.y(), vec.z + offset.z());
     }
 
     protected static Location unapply(Location loc, FixedOffset offset) {
-        loc.setPosition(new Vector3d(loc.getX() + offset.x(), loc.getY(), loc.getZ() + offset.z()));
+        loc.setPosition(new Vector3d(loc.getX() + offset.x(), loc.getY() + offset.y(), loc.getZ() + offset.z()));
         return loc;
     }
 
     protected static WorldBlockPosition apply(WorldBlockPosition pos, FixedOffset offset) {
         // TODO: When available, this could respect the offset of the specific world instead of the Player's current one
         return new WorldBlockPosition(pos.getWorld(),
-                pos.getBlockPosition().x - offset.x(), pos.getBlockPosition().y, pos.getBlockPosition().z - offset.z());
+                pos.getBlockPosition().x - offset.x(), pos.getBlockPosition().y - offset.y(), pos.getBlockPosition().z - offset.z());
     }
 
     protected static Vector3i applyChunk(Vector3i vec, FixedOffset offset) {
@@ -103,7 +103,7 @@ public abstract class PacketOffsetter<T extends PacketWrapper<T>> {
 
     protected static Vector3i applyTimes8(Vector3i vec, FixedOffset offset) {
         // Used for sound effects
-        return new Vector3i(vec.x - (offset.x() * 8), vec.y, vec.z - (offset.z() * 8));
+        return new Vector3i(vec.x - (offset.x() * 8), vec.y - (offset.y() * 8), vec.z - (offset.z() * 8));
     }
 
     /**

--- a/core/src/main/java/com/jtprince/coordinateoffset/offsetter/PacketOffsetter.java
+++ b/core/src/main/java/com/jtprince/coordinateoffset/offsetter/PacketOffsetter.java
@@ -84,6 +84,10 @@ public abstract class PacketOffsetter<T extends PacketWrapper<T>> {
         return x - offset.x();
     }
 
+    protected static double applyY(double y, FixedOffset offset) {
+        return y - offset.y();
+    }
+
     protected static double applyZ(double z, FixedOffset offset) {
         return z - offset.z();
     }

--- a/core/src/main/java/com/jtprince/coordinateoffset/offsetter/server/OffsetterServerPlayerPositionAndLook.java
+++ b/core/src/main/java/com/jtprince/coordinateoffset/offsetter/server/OffsetterServerPlayerPositionAndLook.java
@@ -19,6 +19,9 @@ public class OffsetterServerPlayerPositionAndLook extends PacketOffsetter<Wrappe
         if (!packet.isRelativeFlag(RelativeFlag.X)) {
             packet.setX(applyX(packet.getX(), offset));
         }
+        if (!packet.isRelativeFlag(RelativeFlag.Y)) {
+            packet.setY(applyY(packet.getY(), offset));
+        }
         if (!packet.isRelativeFlag(RelativeFlag.Z)) {
             packet.setZ(applyZ(packet.getZ(), offset));
         }

--- a/core/src/main/java/com/jtprince/coordinateoffset/provider/ConstantOffsetProvider.java
+++ b/core/src/main/java/com/jtprince/coordinateoffset/provider/ConstantOffsetProvider.java
@@ -29,9 +29,11 @@ public final class ConstantOffsetProvider extends CoreOffsetProvider {
         SequencedMap<String, Object> map = new LinkedHashMap<>();
         if (offset == null) {
             map.put("offsetX", (long) 0);
+            map.put("offsetY", (long) 0);
             map.put("offsetZ", (long) 0);
         } else {
             map.put("offsetX", (long) offset.x());
+            map.put("offsetY", (long) offset.y());
             map.put("offsetZ", (long) offset.z());
         }
         return map;
@@ -48,9 +50,10 @@ public final class ConstantOffsetProvider extends CoreOffsetProvider {
             throw new IllegalArgumentException("Provider \"" + config.getUserDefinedProviderName() +
                 "\": Required key offsetZ for ConstantOffsetProvider is missing or invalid.");
         }
-
         int offsetX = offsetXNum.intValue();
         int offsetZ = offsetZNum.intValue();
+        int offsetY = s.containsKey("offsetY") && s.get("offsetY") instanceof Number offsetYNum
+            ? offsetYNum.intValue() : 0;
 
         if (Math.abs(offsetX) > OffsetProvider.OFFSET_MAX) {
             throw new IllegalArgumentException("Provider \"" + config.getUserDefinedProviderName() +
@@ -61,11 +64,15 @@ public final class ConstantOffsetProvider extends CoreOffsetProvider {
                 "\": offsetZ value " + offsetZ + " is too large! (Max 30M)");
         }
 
-        if (offsetX == 0 && offsetZ == 0) {
+        if (offsetX == 0 && offsetY == 0 && offsetZ == 0) {
             return new ConstantOffsetProvider(config.getUserDefinedProviderName(), null);
         } else {
-            ScalableOffset directOffset = Offset.scalable(offsetX, offsetZ);
-            ScalableOffset alignedOffset = Offset.align(offsetX, offsetZ);
+            ScalableOffset directOffset = Offset.scalable(offsetX, offsetY, offsetZ);
+            ScalableOffset alignedOffset = new ScalableOffset(
+                Offset.alignComponentToConfiguredMultiple(offsetX),
+                offsetY,
+                Offset.alignComponentToConfiguredMultiple(offsetZ)
+            );
             if (!directOffset.equals(alignedOffset)) {
                 CoordinateOffsetCore.get().getLogger().warning("Provider \"" + config.getUserDefinedProviderName() +
                     "\": Constant offset " + directOffset + " contains a component which is not a multiple of " +

--- a/paper/src/main/java/com/jtprince/coordinateoffset/paper/adapter/PaperLocation.java
+++ b/paper/src/main/java/com/jtprince/coordinateoffset/paper/adapter/PaperLocation.java
@@ -37,12 +37,12 @@ public class PaperLocation implements OffsetLocation {
 
     @Override
     public OffsetLocation apply(FixedOffset offset) {
-        return new PaperLocation(location.clone().subtract(offset.x(), 0, offset.z()));
+        return new PaperLocation(location.clone().subtract(offset.x(), offset.y(), offset.z()));
     }
 
     @Override
     public OffsetLocation unapply(FixedOffset offset) {
-        return new PaperLocation(location.clone().add(offset.x(), 0, offset.z()));
+        return new PaperLocation(location.clone().add(offset.x(), offset.y(), offset.z()));
     }
 
     @Override

--- a/paper/src/main/java/com/jtprince/coordinateoffset/paper/adapter/PaperPlayerOffsetPersistence.java
+++ b/paper/src/main/java/com/jtprince/coordinateoffset/paper/adapter/PaperPlayerOffsetPersistence.java
@@ -75,11 +75,15 @@ public class PaperPlayerOffsetPersistence implements OffsetPersistenceAdapter {
     }
 
     private static ScalableOffset fromPdt(int[] arr) {
-        return Offset.scalable(arr[0], arr[1]);
+        if (arr.length >= 3) {
+            return Offset.scalable(arr[0], arr[1], arr[2]);
+        } else {
+            return Offset.scalable(arr[0], 0, arr[1]);
+        }
     }
 
     private static int[] toPdt(ScalableOffset offset) {
-        return new int[] { offset.x(), offset.z() };
+        return new int[] { offset.x(), offset.y(), offset.z() };
     }
 
     private NamespacedKey persistenceKeyToBukkitKey(Key persistenceKey) {


### PR DESCRIPTION
## Summary

this adds `y-axis` coordinate support to the plugin. this enables the plugin to shift the player's perceived `y` coordinate, allowing server owners to fake their vertical position (eg, hiding sub-level dungeons).

**Closes #44**
**Related:** #14 (context regarding historical limitations and `ViaBackwards` compatibility, i can probably just fix this while i'm in here)

## Changes

- [x] add `y` field to `FixedOffset`
- [x] add `y` field to `ScalableOffset`
- [x] add `y` support to `Offset` factory methods
- [x] update all `PacketOffsetter` helper methods with 3D math (using `y` for all packet types)
- [x] add `offsetY` config key to `ConstantOffsetProvider`
- [x] update `PaperPlayerOffsetPersistence` serialization to support 3-element coordinate arrays
- [x] update `TestOffset` with `y` coordinate unit tests

## Implementation Notes

- [x] the `FixedOffset` API has been broken (3D instead of 2D) to cleanly support `y`. `Offset` factory shorthands remain for 2D compatibility.
- [x] `PacketOffsetter` now offsets `y` symmetrically (`apply` subtracts offset, `unapply` adds it back).
- [x] `applyTimes8` updated to shift sound effects alongside player movement.

i've verified this with a successful build and basic server tests. ~~this is currently a draft; looking for a sanity check on the sign convention in `PacketOffsetter` before we merge.~~